### PR TITLE
Documentation updates for #205 and #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The command will create the `docs` directory and `index.rst` file if they do not
 
 Press `Ctrl+C` at any time to exit.
 
-Most changes in `index.rst` or other documentation source files will be processed immediately and shown in browser, for deep changes (eg use a different theme) to take effect you need stop the live server with `Ctrl-C` and start it again with `mudkip develop` command.
+Most changes in `index.rst` or other documentation source files will be processed immediately and shown in browser. Deep changes (eg using a different theme) take effect after you stop and restart the live server.
 
 ### Building and checking documentation
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ Watching "docs"...
 Server running on http://localhost:5500
 ```
 
-The command will create the "docs" directory if it doesn't already exist and launch a development server with live reloading. If you create an `index.rst` file and open the link in your browser, you'll see that mudkip uses the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme by default.
+The command will create the `docs` directory and `index.rst` file if they do not already exist and launch a development server with live reloading. You can open the link in your browser and see that mudkip uses the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme by default.
 
 > Note that mudkip enables the [`myst_parser`](https://myst-parser.readthedocs.io/en/latest/) extension, allowing you to use both reStructuredText and markdown files. You can create an `index.md` file if you want to use markdown instead of reStructuredText.
 
 Press `Ctrl+C` at any time to exit.
+
+Most changes in `index.rst` or other documentation source files will be processed immediately and shown in browser, for deep changes (eg use a different theme) to take effect you need stop the live server with `Ctrl-C` and start it again with `mudkip develop` command.
 
 ### Building and checking documentation
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ mudkip build --source-dir path/to/docs --output-dir path/to/output
 
 Passing these options to every single command can become tedious so you can use a configuration file to save your custom settings.
 
-Running the `init` command will either add a `[tool.mudkip]` section to your `pyproject.toml` or create a `mudkip.toml` file with some basic configuration.
+Running the `init` command will either add a `[tool.mudkip]` section to your existing `pyproject.toml` or create a new `mudkip.toml` file with some basic configuration.
 
 ```bash
 $ mudkip init
@@ -274,7 +274,18 @@ $ mudkip init
 
   **default**: An empty dictionary
 
-  The `override` option lets you override sphinx configuration directly. You can use it to specify a custom theme or a logo for instance.
+  The `override` option lets you specify sphinx configuration directly. For example, you can use it to define a custom theme or a logo image. 
+
+  Note that `override` option is effectively a replacement for `conf.py` configuration. 
+  You can specify an `override` section in `mudkip.toml` file as shown in example below.  
+
+  ```toml
+  [mudkip.override]
+  myst_enable_extensions = ["replacements", "tasklist"]
+  html_static_path = ["_static"]
+  ```
+
+  In a `pyproject.toml` file this section name should be `[tool.mudkip.override]`.
 
 - `section_label_depth`
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ The package can be installed with `pip`.
 $ pip install mudkip
 ```
 
+To use the development version:
+
+```bash
+$ pip install update git+https://github.com/vberlier/mudkip.git
+```
+
 ## Getting started
 
 You can forget everything about `sphinx-quickstart`, `conf.py` and intimidating Makefiles. After installing the package, no need to configure anything you can run the `develop` command right away and start writing docs.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,14 @@ $ mudkip init
 
   **default**: `"rtd"`
 
-  Presets configure Mudkip and Sphinx to enable specific features. The `rtd`, `furo` and `alabaster` presets enable the development server and configure Sphinx to use the `dirhtml` builder. The `rtd` preset changes the html theme to the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme and the `furo` preset to the [Furo](https://pradyunsg.me/furo/) theme.
+  Presets configure Mudkip and Sphinx to enable specific features. The `rtd`, `furo`, `pydata` and `alabaster` presets enable the development server and configure Sphinx to use the `dirhtml` builder. The `rtd` preset changes the html theme to the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme, `furo` preset uses [Furo](https://pradyunsg.me/furo/) theme, and
+  `pydata` changes to [PyData](https://pydata-sphinx-theme.readthedocs.io/en/stable/) theme.
 
-  The `xml` preset configures Sphinx to use the `xml` builder. This is useful for more advanced use-cases when you have a separate static site generator that can process a hierarchy of docutils documents.
+  The `xml` preset configures Sphinx to use the `xml` builder. This is useful for more advanced usecases when you process a hierarchy of docutils documents further in your static site generator pipeline (experimental).
+
+  The `latex` preset uses `latex` builder that is used to generate a PDF version of your
+  documentation. You may want to change `--output-dir` manually to a different directory 
+  when using `latex` preset.
 
 - `source_dir`
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Server running on http://localhost:5500
 The command will create the `docs` directory and `index.rst` file if they do not already exist and launch a development server with live reloading. You can open the link in your browser and see that mudkip uses the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme by default.
 
 > Note that mudkip enables the [`myst_parser`](https://myst-parser.readthedocs.io/en/latest/) extension, allowing you to use both reStructuredText and markdown files. You can create an `index.md` file if you want to use markdown instead of reStructuredText.
-Check out this project's own [`docs` folder](https://github.com/vberlier/mudkip/tree/main/docs) as an example.
+> Check out this project's own [`docs` folder](https://github.com/vberlier/mudkip/tree/main/docs) as an example.
 
 Press `Ctrl+C` at any time to exit.
 
@@ -201,9 +201,9 @@ $ mudkip init
 
   Presets configure Mudkip and Sphinx to enable specific features. The `rtd`, `furo`, `pydata` and `alabaster` presets enable the development server and configure Sphinx to use the `dirhtml` builder. The `rtd` preset changes the html theme to the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme, `furo` preset uses [Furo](https://pradyunsg.me/furo/) theme, and `pydata` changes to [PyData](https://pydata-sphinx-theme.readthedocs.io/en/stable/) theme.
 
-  The `xml` preset configures Sphinx to use the `xml` builder. This is useful for more advanced usecases when you process a hierarchy of docutils documents further in your static site generator pipeline (experimental).
+  The `xml` preset configures Sphinx to use the `xml` builder. This is useful for more advanced use cases when you process a hierarchy of docutils documents further in your static site generator pipeline (experimental).
 
-  The `latex` preset uses `latex` builder, which creates source files for making a PDF version of your documentation. You may want to change `--output-dir` manually to a different directory when using `latex` preset to separate HTML and latex outputs.
+  The `latex` preset uses `latex` builder, which creates LaTeX source files for making a PDF version of your documentation. You may want to change `--output-dir` manually to a different directory when using `latex` preset to separate HTML and LaTeX outputs.
 
 - `source_dir`
 
@@ -283,10 +283,10 @@ $ mudkip init
 
   **default**: An empty dictionary
 
-  The `override` option lets you specify sphinx configuration directly. For example, you can use it to define a custom theme or a logo image. 
+  The `override` option lets you specify sphinx configuration directly. For example, you can use it to define a custom theme or a logo image.
 
-  Note that `override` option is effectively a replacement for `conf.py` configuration. 
-  You can put an `override` section in `mudkip.toml` file as shown in an example below.  
+  Note that `override` option is effectively a replacement for `conf.py` configuration.
+  You can put an `override` section in `mudkip.toml` file as shown in an example below.
 
   ```toml
   [mudkip.override]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Server running on http://localhost:5500
 The command will create the `docs` directory and `index.rst` file if they do not already exist and launch a development server with live reloading. You can open the link in your browser and see that mudkip uses the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme by default.
 
 > Note that mudkip enables the [`myst_parser`](https://myst-parser.readthedocs.io/en/latest/) extension, allowing you to use both reStructuredText and markdown files. You can create an `index.md` file if you want to use markdown instead of reStructuredText.
+Check out this project's own [`docs` folder](https://github.com/vberlier/mudkip/tree/main/docs) as an example.
 
 Press `Ctrl+C` at any time to exit.
 
@@ -198,14 +199,11 @@ $ mudkip init
 
   **default**: `"rtd"`
 
-  Presets configure Mudkip and Sphinx to enable specific features. The `rtd`, `furo`, `pydata` and `alabaster` presets enable the development server and configure Sphinx to use the `dirhtml` builder. The `rtd` preset changes the html theme to the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme, `furo` preset uses [Furo](https://pradyunsg.me/furo/) theme, and
-  `pydata` changes to [PyData](https://pydata-sphinx-theme.readthedocs.io/en/stable/) theme.
+  Presets configure Mudkip and Sphinx to enable specific features. The `rtd`, `furo`, `pydata` and `alabaster` presets enable the development server and configure Sphinx to use the `dirhtml` builder. The `rtd` preset changes the html theme to the [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme) theme, `furo` preset uses [Furo](https://pradyunsg.me/furo/) theme, and `pydata` changes to [PyData](https://pydata-sphinx-theme.readthedocs.io/en/stable/) theme.
 
   The `xml` preset configures Sphinx to use the `xml` builder. This is useful for more advanced usecases when you process a hierarchy of docutils documents further in your static site generator pipeline (experimental).
 
-  The `latex` preset uses `latex` builder that is used to generate a PDF version of your
-  documentation. You may want to change `--output-dir` manually to a different directory 
-  when using `latex` preset.
+  The `latex` preset uses `latex` builder, which creates source files for making a PDF version of your documentation. You may want to change `--output-dir` manually to a different directory when using `latex` preset to separate HTML and latex outputs.
 
 - `source_dir`
 
@@ -288,7 +286,7 @@ $ mudkip init
   The `override` option lets you specify sphinx configuration directly. For example, you can use it to define a custom theme or a logo image. 
 
   Note that `override` option is effectively a replacement for `conf.py` configuration. 
-  You can specify an `override` section in `mudkip.toml` file as shown in example below.  
+  You can put an `override` section in `mudkip.toml` file as shown in an example below.  
 
   ```toml
   [mudkip.override]
@@ -296,7 +294,7 @@ $ mudkip init
   html_static_path = ["_static"]
   ```
 
-  In a `pyproject.toml` file this section name should be `[tool.mudkip.override]`.
+  In a `pyproject.toml` file the `override` section name should be `[tool.mudkip.override]`.
 
 - `section_label_depth`
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ The code follows the [black](https://github.com/psf/black) code style.
 $ poetry run black mudkip
 ```
 
+## Why package name Mudkip?
+
+[wiki]: https://en.wikipedia.org/wiki/List_of_generation_III_Pok%C3%A9mon#Mudkip
+
+This package started as a hobby project, which **@vberlier** usually named after Pokémon characters. [Mudkip][wiki] _"has a fin on its head, which acts as a radar for its surroundings. Even in muddy water, Mudkip can sense where it is going."_ Cute video about Mudkip [here](https://www.youtube.com/watch?v=l7kK9bxEGMg).
+
 ---
 
 License - [MIT](https://github.com/vberlier/mudkip/blob/master/LICENSE)


### PR DESCRIPTION
New text:

- section on mudkip name
- `override` option as conf.py replacement
- pydata and latex presets
- must restart the live server for deep changes
- install dev version from git
- link to own docs folder as an index.md example 

Suggested changes on existing text:

- use case without hyphen
- reworded xml preset decription (avoid implying specific SSG)

I tried prefix the commits with `docs` but succeeded just partially.

README.md linted with [prettier](https://prettier.io/) for consistent formatting.